### PR TITLE
Port upstream libdeflate 1.18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing to Unikraft
+
+Contributions to Unikraft are welcome!
+Please refer to the [Contributing](https://unikraft.org/docs/contributing/) page for further information.

--- a/Config.uk
+++ b/Config.uk
@@ -1,0 +1,5 @@
+config LIBDEFLATE
+    bool "libdeflate - fast DEFLATE compression library"
+    imply LIBINTEL_INTRINSICS if ARCH_X86_64
+    imply LIBARM_INTRINSICS if ARCH_ARM_32 || ARCH_ARM_64
+    default n

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,0 +1,88 @@
+#  libdeflate Makefile.uk
+#
+#  Authors: Andrei Tatar <andrei@unikraft.io>
+#
+#  Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+################################################################################
+# Library registration
+################################################################################
+$(eval $(call addlib_s,libdeflate,$(CONFIG_LIBDEFLATE)))
+
+################################################################################
+# Sources
+################################################################################
+LIBDEFLATE_VERSION=1.18
+LIBDEFLATE_URL=https://github.com/ebiggers/libdeflate/archive/refs/tags/v$(LIBDEFLATE_VERSION).tar.gz
+LIBDEFLATE_DIRNAME=libdeflate-$(LIBDEFLATE_VERSION)
+LIBDEFLATE_PATCHDIR=$(LIBDEFLATE_BASE)/patches
+$(eval $(call fetch,libdeflate,$(LIBDEFLATE_URL)))
+$(eval $(call patch,libdeflate,$(LIBDEFLATE_PATCHDIR),$(LIBDEFLATE_DIRNAME)))
+
+################################################################################
+# Helpers
+################################################################################
+LIBDEFLATE_SRC = $(LIBDEFLATE_ORIGIN)/$(LIBDEFLATE_DIRNAME)
+
+################################################################################
+# Library includes
+################################################################################
+# API
+LIBDEFLATE__API += -I$(LIBDEFLATE_SRC)
+
+CINCLUDES-$(CONFIG_LIBDEFLATE) += $(LIBDEFLATE__API)
+CXXINCLUDES-$(CONFIG_LIBDEFLATE) += $(LIBDEFLATE__API)
+
+################################################################################
+# Global flags
+################################################################################
+LIBDEFLATE_CFLAGS += -Wno-sign-compare
+LIBDEFLATE_CFLAGS += -Wno-unused-parameter
+LIBDEFLATE_CFLAGS-$(call have_clang) += -Wno-documentation
+LIBDEFLATE_CFLAGS-$(call have_clang) += -Wno-documentation-unknown-command
+
+################################################################################
+# Library sources
+################################################################################
+# These sources are grouped by directory and sorted in alphabetical order.
+# Please maintain grouping and ordering when updating.
+################################################################################
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/adler32.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/crc32.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/gzip_compress.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/gzip_decompress.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/zlib_compress.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/zlib_decompress.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/deflate_compress.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/deflate_decompress.c
+LIBDEFLATE_SRCS-y += $(LIBDEFLATE_SRC)/lib/utils.c
+
+LIBDEFLATE_SRCS-$(CONFIG_ARCH_ARM_32) += $(LIBDEFLATE_SRC)/lib/arm/cpu_features.c
+LIBDEFLATE_SRCS-$(CONFIG_ARCH_ARM_64) += $(LIBDEFLATE_SRC)/lib/arm/cpu_features.c
+LIBDEFLATE_SRCS-$(CONFIG_ARCH_X86_64) += $(LIBDEFLATE_SRC)/lib/x86/cpu_features.c

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# lib-libdeflate
-Library for fast, whole-buffer DEFLATE-based compression and decompression
+# libdeflate for Unikraft
+
+This is a port of [libdeflate](https://github.com/ebiggers/libdeflate) to Unikraft.
+
+Please refer to `README.md` in the main unikraft repository as well as the [Unikraft Homepage](https://unikraft.org/) for further information.

--- a/patches/0001-Adapt-x86-intrinsics-to-Unikraft-build-system.patch
+++ b/patches/0001-Adapt-x86-intrinsics-to-Unikraft-build-system.patch
@@ -1,0 +1,105 @@
+From 1d3ae463ca104d5e6e5604cb61f180e8ac89ecf6 Mon Sep 17 00:00:00 2001
+From: Andrei Tatar <andrei@unikraft.io>
+Date: Tue, 1 Aug 2023 17:48:40 +0200
+Subject: [PATCH] Adapt x86 intrinsics to Unikraft build system
+
+This minimal patch allows libdeflate to work with the way Unikraft's
+build system handles compiler intrinsics; specifically:
+
+(1) Remove HAVE_*_NATIVE macros => intrinsics will only be included and
+used if HAVE_TARGET_INTRINSICS is set
+(2) Condition HAVE_TARGET_INTRINSICS on LIBINTEL_INTRINSICS, to ensure
+that the build has *intrin.h files
+
+This way the intrinsics headers will only be included if they are
+provided by LIBINTEL_INTRINSICS and individual CPU feature selection is
+left to the compiler's 'target' function attributes & runtime dispatch.
+
+Signed-off-by: Andrei Tatar <andrei@unikraft.io>
+---
+ lib/x86/cpu_features.h | 26 +++-----------------------
+ 1 file changed, 3 insertions(+), 23 deletions(-)
+
+diff --git a/lib/x86/cpu_features.h b/lib/x86/cpu_features.h
+index 3cb3f46..eeb2ba8 100644
+--- a/lib/x86/cpu_features.h
++++ b/lib/x86/cpu_features.h
+@@ -28,6 +28,8 @@
+ #ifndef LIB_X86_CPU_FEATURES_H
+ #define LIB_X86_CPU_FEATURES_H
+ 
++#include <uk/config.h>
++
+ #include "../lib_common.h"
+ 
+ #define HAVE_DYNAMIC_X86_CPU_FEATURES	0
+@@ -73,7 +75,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
+  * functions.  Unfortunately clang has no feature test macro for this, so we
+  * have to check its version.
+  */
+-#if HAVE_DYNAMIC_X86_CPU_FEATURES && \
++#if HAVE_DYNAMIC_X86_CPU_FEATURES && CONFIG_LIBINTEL_INTRINSICS && \
+ 	(GCC_PREREQ(4, 9) || CLANG_PREREQ(3, 8, 7030000) || defined(_MSC_VER))
+ #  define HAVE_TARGET_INTRINSICS	1
+ #else
+@@ -81,21 +83,11 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
+ #endif
+ 
+ /* SSE2 */
+-#if defined(__SSE2__) || \
+-	(defined(_MSC_VER) && \
+-	 (defined(ARCH_X86_64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)))
+-#  define HAVE_SSE2_NATIVE	1
+-#else
+ #  define HAVE_SSE2_NATIVE	0
+-#endif
+ #define HAVE_SSE2_INTRIN	(HAVE_SSE2_NATIVE || HAVE_TARGET_INTRINSICS)
+ 
+ /* PCLMUL */
+-#if defined(__PCLMUL__) || (defined(_MSC_VER) && defined(__AVX2__))
+-#  define HAVE_PCLMUL_NATIVE	1
+-#else
+ #  define HAVE_PCLMUL_NATIVE	0
+-#endif
+ #if HAVE_PCLMUL_NATIVE || (HAVE_TARGET_INTRINSICS && \
+ 			   (GCC_PREREQ(4, 4) || CLANG_PREREQ(3, 2, 0) || \
+ 			    defined(_MSC_VER)))
+@@ -105,11 +97,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
+ #endif
+ 
+ /* AVX */
+-#ifdef __AVX__
+-#  define HAVE_AVX_NATIVE	1
+-#else
+ #  define HAVE_AVX_NATIVE	0
+-#endif
+ #if HAVE_AVX_NATIVE || (HAVE_TARGET_INTRINSICS && \
+ 			(GCC_PREREQ(4, 6) || CLANG_PREREQ(3, 0, 0) || \
+ 			 defined(_MSC_VER)))
+@@ -119,11 +107,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
+ #endif
+ 
+ /* AVX2 */
+-#ifdef __AVX2__
+-#  define HAVE_AVX2_NATIVE	1
+-#else
+ #  define HAVE_AVX2_NATIVE	0
+-#endif
+ #if HAVE_AVX2_NATIVE || (HAVE_TARGET_INTRINSICS && \
+ 			 (GCC_PREREQ(4, 7) || CLANG_PREREQ(3, 1, 0) || \
+ 			  defined(_MSC_VER)))
+@@ -133,11 +117,7 @@ static inline u32 get_x86_cpu_features(void) { return 0; }
+ #endif
+ 
+ /* BMI2 */
+-#if defined(__BMI2__) || (defined(_MSC_VER) && defined(__AVX2__))
+-#  define HAVE_BMI2_NATIVE	1
+-#else
+ #  define HAVE_BMI2_NATIVE	0
+-#endif
+ #if HAVE_BMI2_NATIVE || (HAVE_TARGET_INTRINSICS && \
+ 			 (GCC_PREREQ(4, 7) || CLANG_PREREQ(3, 1, 0) || \
+ 			  defined(_MSC_VER)))
+-- 
+2.41.0
+


### PR DESCRIPTION
Includes patch to adapt intrinsics handling to the Unikraft build.